### PR TITLE
Fix compilation for linux implementation

### DIFF
--- a/src/api/linux/mod.rs
+++ b/src/api/linux/mod.rs
@@ -1,6 +1,5 @@
 use gtk::{ self, WidgetExt, MenuShellExt, GtkMenuItemExt };
-use libappindicator::{AppIndicator,
-                      AppIndicatorStatus_APP_INDICATOR_STATUS_ACTIVE};
+use libappindicator::{AppIndicator, AppIndicatorStatus};
 use std::cell::{RefCell};
 use std::collections::HashMap;
 use {SystrayEvent, SystrayError};
@@ -54,7 +53,7 @@ impl GtkSystrayApp {
         }
         let mut m = gtk::Menu::new();
         let mut ai = AppIndicator::new("", "");
-        ai.set_status(AppIndicatorStatus_APP_INDICATOR_STATUS_ACTIVE);
+        ai.set_status(AppIndicatorStatus::Active);
         ai.set_menu(&mut m);
         Ok(GtkSystrayApp {
             menu: m,


### PR DESCRIPTION
7ef0438afd3ec313d241130e87e7a29370baf142 in libappindicator-rs changed
the implementation of AppIndicatorStatus so that the reexported constant
is not a valid parameter for `set_status` anymore.