### PR TITLE
Add support for set_icon_by_name in Linux

### DIFF
--- a/src/api/linux/mod.rs
+++ b/src/api/linux/mod.rs
@@ -108,6 +108,11 @@ impl GtkSystrayApp {
         let mut ai = self.ai.borrow_mut();
         ai.set_icon_full(file, "icon");
     }
+
+    pub fn set_icon_from_name(&self, name: &str) {
+        let mut ai = self.ai.borrow_mut();
+        ai.set_icon(name);
+    }
 }
 
 pub struct Window {
@@ -157,6 +162,14 @@ impl Window {
         let n = file.to_owned().clone();
         run_on_gtk_thread(move |stash: &GtkSystrayApp| {
             stash.set_icon_from_file(&n);
+        });
+        Ok(())
+    }
+
+    pub fn set_icon_from_name(&self, name: &str) -> Result<(), Error> {
+        let n = name.to_owned().clone();
+        run_on_gtk_thread(move |stash: &GtkSystrayApp| {
+            stash.set_icon_from_name(&n);
         });
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,6 +107,11 @@ impl Application {
         self.window.set_icon_from_file(file)
     }
 
+    #[cfg(target_os = "linux")]
+    pub fn set_icon_from_name(&self, name: &str) -> Result<(), Error> {
+        self.window.set_icon_from_name(name)
+    }
+
     pub fn set_icon_from_resource(&self, resource: &str) -> Result<(), Error> {
         self.window.set_icon_from_resource(resource)
     }


### PR DESCRIPTION
This PR adds support for the new `set_icon` method recently added in qdot/libappindicator-rs#9.

The new `set_icon_by_name` method allows users to set the icon using the name of an icon in the active system icon theme, without needing to provide the full path.