### PR TITLE
feat: Expose `timeout` parameter to the main event loop

### DIFF
--- a/examples/systray-example.rs
+++ b/examples/systray-example.rs
@@ -33,7 +33,7 @@ fn main() -> Result<(), systray::Error> {
     })?;
 
     println!("Waiting on message!");
-    app.wait_for_message(None)?;
+    app.wait_for_message()?;
     Ok(())
 }
 

--- a/examples/systray-example.rs
+++ b/examples/systray-example.rs
@@ -33,7 +33,7 @@ fn main() -> Result<(), systray::Error> {
     })?;
 
     println!("Waiting on message!");
-    app.wait_for_message()?;
+    app.wait_for_message(None)?;
     Ok(())
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ pub enum Error {
     NotImplementedError,
     UnknownError,
     Error(BoxedError),
+    TimeoutError,
 }
 
 impl From<BoxedError> for Error {
@@ -39,6 +40,7 @@ impl fmt::Display for Error {
             NotImplementedError => write!(f, "Functionality is not implemented yet"),
             UnknownError => write!(f, "Unknown error occurrred"),
             Error(ref e) => write!(f, "Error: {}", e),
+            TimeoutError => write!(f, "Timeout"),
         }
     }
 }
@@ -134,16 +136,17 @@ impl Application {
         self.window.quit()
     }
 
-    pub fn wait_for_message(&mut self, timeout: Option<Duration>) -> Result<(), Error> {
+    pub fn wait_for_message(&mut self) -> Result<(), Error> {
+        self.try_wait(Duration::new(u64::MAX, 0))
+    }
+
+    pub fn try_wait(&mut self, timeout: Duration) -> Result<(), Error> {
         loop {
             let msg;
-            match self
-                .rx
-                .recv_timeout(timeout.unwrap_or_else(|| Duration::new(u64::MAX, 0)))
-            {
+            match self.rx.recv_timeout(timeout) {
                 Ok(m) => msg = m,
                 // Yield and wait for the next poll
-                Err(RecvTimeoutError::Timeout) => break,
+                Err(RecvTimeoutError::Timeout) => return Err(Error::TimeoutError),
                 Err(RecvTimeoutError::Disconnected) => {
                     self.quit();
                     break;


### PR DESCRIPTION
feat: Expose `timeout` parameter to the main event loop, such that co…
is passed back to an external caller. This provides more flexibility to the API
user.

Related #43 #38